### PR TITLE
Respond to updated query

### DIFF
--- a/components/VegaLite.vue
+++ b/components/VegaLite.vue
@@ -28,15 +28,20 @@ export default {
   async mounted() {
     const loadedSpec = await fetch(this.spec).then(res => res.json());
 
-    // Parse query from route and update spec with requested datasets pre-selected
+    // Get project from query and update selection
+    const project = this.$route.query.project ? this.$route.query.project : "CMIP6";
+    loadedSpec.params.find(obj => obj.name === "Project").value = project;
+
+    // Get datasets from query and update selection
     const datasets = this.$route.query.dataset ? this.$route.query.dataset : [];
     this.selection = datasets;
     const params = datasets.map(item => {
       const listobj = {};
-      listobj["dataset"] = item;
+      listobj["model"] = item;
       return listobj;
     });
     loadedSpec.params.find(obj => obj.name === "query").value = params;
+
 
     // Embed the vegalite spec
     const updateList = this.updateList;
@@ -48,7 +53,8 @@ export default {
   },
   methods: {
     updateList(event, newSelection) {
-      this.selection = newSelection.dataset;
+      console.log(newSelection)
+      this.selection = newSelection.model;
     }
   }
 };

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -11,6 +11,7 @@
       <li>Future change is calculated for 2036-2065 as compared to
   1986-2015.</li>
       <li>Area is set to Europe (lon 0-39; lat 30-76.25)</li>
+      <li>All data are taken from the RCP/SSP 8.5 scenario</li>
     </ul>
     </p>
     <p>Hold ctrl to pan and zoom, hold alt to select a range (points will be

--- a/static/specs/vegalite_spec.json
+++ b/static/specs/vegalite_spec.json
@@ -2,7 +2,7 @@
     "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
     "description": "CMIP data processed with ESMValTool.",
     "data": {
-        "url": "/data/recipe_output.csv"
+        "url": "data/recipe_output.csv"
     },
     "config": {
         "view": {
@@ -49,12 +49,12 @@
                 "type": "point",
                 "clear": "dblclick",
                 "fields": [
-                    "dataset"
+                    "model"
                 ]
             },
             "value": [
-                {"dataset": "CMIP5_IPSL-CM5B-LR_r1i1p1"},
-                {"dataset": "CMIP5_FGOALS-g2_r1i1p1"}
+                {"model": "IPSL-CM5B-LR"},
+                {"model": "FGOALS-g2"}
             ]
         }
     ],
@@ -111,7 +111,15 @@
                 },
                 "tooltip": [
                     {
-                        "field": "dataset",
+                        "field": "model",
+                        "type": "nominal"
+                    },
+                    {
+                        "field": "member",
+                        "type": "nominal"
+                    },
+                    {
+                        "field": "project",
                         "type": "nominal"
                     }
                 ]
@@ -162,7 +170,15 @@
                 },
                 "tooltip": [
                     {
-                        "field": "dataset",
+                        "field": "model",
+                        "type": "nominal"
+                    },
+                    {
+                        "field": "member",
+                        "type": "nominal"
+                    },
+                    {
+                        "field": "project",
                         "type": "nominal"
                     }
                 ]


### PR DESCRIPTION
The updated query has the form:

https://esmvaltool.cloud.dkrz.de/shared/esmvaltool/climate4impact/?project=CMIP5&dataset=EC-EARTH&dataset=CanESM2

Before, the project and dataset were combined into one query. Now, the project is used to set the dropdown selection, whereas the dataset is used for the initial selections. 

A side-effect is that all ensemble members of a selection will be highlighted simultaneously. This might actually be informative, and since it's quite tricky to circumvent, I suggest to just keep it like this.